### PR TITLE
Fix crash when pasting null/0 entities; also add support for the SpinSign

### DIFF
--- a/ManiacEditor/EditorEntities.cs
+++ b/ManiacEditor/EditorEntities.cs
@@ -130,6 +130,8 @@ namespace ManiacEditor
 
         private void DuplicateEntities(List<EditorEntity> entities)
         {
+            if (null == entities || !entities.Any()) return;
+            
             var new_entities = entities.Select(x => new EditorEntity(new RSDKv5.SceneEntity(x.Entity, getFreeSlot(x.Entity)))).ToList();
             if (new_entities.Count > 0)
                 LastAction = new Actions.ActionAddDeleteEntities(new_entities.ToList(), true, x => AddEntities(x), x => DeleteEntities(x));

--- a/ManiacEditor/Resources/objects_attributes.ini
+++ b/ManiacEditor/Resources/objects_attributes.ini
@@ -1543,6 +1543,9 @@ forwardOnly=BOOL
 playSound=BOOL
 allowTubeInput=BOOL
 
+[SpinSign]
+type=UINT8
+
 [Spiny]
 type=UINT8
 direction=UINT8


### PR DESCRIPTION
I'm not particularly familiar with Git, GitHub, or Open Source etiquette, but hopefully I'm getting this right. (This change was Cherry Picked from my master branch.)

The SpinSign addition fixes entity 1380 in Studiopolis Act 1 for example; while the pasting fix prevents an error if you hit Ctrl+V without first getting an entity into your entity clipboard.

Please let me know if any of my other changes are suitable for firing over further Pull Requests.